### PR TITLE
Enable lone modifiers as basic keybinds

### DIFF
--- a/mugur.el
+++ b/mugur.el
@@ -228,7 +228,10 @@ the same form.")
   "Generate simple keys or key sequences, like M-x or C-M-a.
 If SS is t, generate the key sequence as needed by SEND_STRING
 macros."
-  (cond ((awhen (mugur--keycode key :ss ss) it))
+  (cond ((awhen (mugur--keycode key :ss ss)
+           (if (mugur--modifier-key-p key)
+               (concat "KC_" it)
+             it)))
         ((s-contains? "-" (if (symbolp key)
                               (symbol-name key)
                             ""))

--- a/tests.el
+++ b/tests.el
@@ -42,7 +42,7 @@
   (cl-dolist (test
        '((()      "___")
          ((c)     "KC_C")
-         ((C)     "LCTL")
+         ((C)     "KC_LCTL")
          ((M-a)   "LALT(KC_A)")
          ((C-M-a) "LCA(KC_A)")
          ((x y)   "TD(TD_X_Y)")


### PR DESCRIPTION
Hi! Thanks for making mugur. I'm trying to convert my existing layout to use it and on one layer I have just a plain old modifier key `KC_LCTL`, and I don't think there's currently a way to bind it with mugur. This change adds it so that a "bare" modifier like `(C)` will be converted to the left modifier equivalent; previously it would have become `LCTL` and the resulting keymap.c could not be compiled.