### PR TITLE
modify the modifiers

### DIFF
--- a/mugur.el
+++ b/mugur.el
@@ -664,7 +664,7 @@ mugur-modifiers, return a list of qmk-raw-modifiers, as strings,
 otherwise return nil."
   (aand (listp mugur-modifiers)
         (mapcar #'mugur--to-string mugur-modifiers)
-        (and (not (-difference it '("C" "M" "S" "G")))
+        (and (not (-difference it '("C" "M" "S" "G" "rctrl" "ropt" "rsft" "rcmd" "H")))
              it)
         (mapcar #'mugur--keycode it)
         (and (not (-some #'null it))


### PR DESCRIPTION
Extending the `mugur-modifiers` to include a few more of the QMK mappings should enable more modifier prefixes. 