### PR TITLE
update deprecated keycodes and include quantum.h

### DIFF
--- a/mugur.el
+++ b/mugur.el
@@ -235,261 +235,275 @@ KC_F6, as a string)."
 (defun mugur--symbol (mugur-key)
   "If MUGUR-KEY is a valid qmk symbol, return its qmk-keycode, nil otherwise.
 MUGUR-KEY can be any of the basic qmk keycodes, like punctuation,
-modifiers, media keys, mouse keys, symbols like '?' and '.' and
+modifiers, media keys, mouse keys, symbols like '?                 ' and   '.                                     ' and
 other special keys that all have a direct qmk-keycode
 equivalent."
   (pcase mugur-key
     ;; Punctuation
-    ((or 'RET               'ent       ) "KC_ENTER"               ) ;Return (Enter)
-    ((or 'escape            'esc       ) "KC_ESCAPE"              ) ;Escape
-    ((or 'backspace         'bspace    ) "KC_BSPACE"              ) ;Delete (Backspace)
-    ((or 'tab               'tab       ) "KC_TAB"                 ) ;Tab
-    ((or 'space             'spc       ) "KC_SPACE"               ) ;Spacebar
-    ((or 'minus             ?\-)         "KC_MINUS"               ) ;- and _
-    ((or 'equal             ?\=)         "KC_EQUAL"               ) ;= and +
-    ((or 'lbracket          ?\[        ) "KC_LBRACKET"            ) ;[ and {
-    ((or 'rbracket          ?\]        ) "KC_RBRACKET"            ) ;] and }
-    ((or 'bslash            ?\\        ) "KC_BSLASH"              ) ;\ and |
-    (    'nonus-hash                     "KC_NONUS_HASH"          ) ;Non-US # and ~
-    ((or 'scolon            ?\;        ) "KC_SCOLON"              ) ;; and :
-    ((or 'quote             ?\'        ) "KC_QUOTE"               ) ;' and
-    ((or 'grave             ?\`        ) "KC_GRAVE"               ) ;` and ~, JIS Zenkaku/Hankaku
-    ((or 'comma             ?\,        ) "KC_COMMA"               ) ;, and <
-    ((or 'dot               ?\.        ) "KC_DOT"                 ) ;. and >
-    ((or 'slash             ?\/        ) "KC_SLASH"               ) ;/ and ?
+    ((or	'RET               'ent       ) "KC_ENTER"               ) ;Return (Enter)
+    ((or	'escape            'esc       ) "KC_ESCAPE"              ) ;Escape
+    ((or	'backspace 'bspc   'bspace    ) "KC_BSPACE"              ) ;Delete (Backspace)
+    ((or	'tab               'tab       ) "KC_TAB"                 ) ;Tab
+    ((or	'space             'spc       ) "KC_SPACE"               ) ;Spacebar
+    ((or	'minus             'mins ?\-  ) "KC_MINUS"               ) ;- and _
+    ((or	'equal             ?\=        ) "KC_EQUAL"               ) ;= and +
+    ((or	'lbracket          'lbrc ?\[  ) "KC_LEFT_BRACKET"        ) ;[ and {
+    ((or	'rbracket          'rbrc ?\]  ) "KC_RIGHT_BRACKET"       ) ;] and }
+    ((or	'bslash            'bsls ?\\  ) "KC_BACKSLASH"           ) ;\ and |
+    (   	'nonus-hash        'nuhs        "KC_NONUS_HASH"          ) ;Non-US # and ~
+    ((or	'scolon            'scln ?\;  ) "KC_SEMICOLON"           ) ;; and :
+    ((or	'quote             'quot ?\'  ) "KC_QUOTE"               ) ;' and
+    ((or	'grave             'grv ?\`   ) "KC_GRAVE"               ) ;` and ~, JIS Zenkaku/Hankaku
+    ((or	'comma             'comm ?\,  ) "KC_COMMA"               ) ;, and <
+    ((or	'dot               ?\.        ) "KC_DOT"                 ) ;. and >
+    ((or	'slash             'slsh ?\/  ) "KC_SLASH"               ) ;/ and ?
+    ((or	'nubs                         ) "KC_NONUS_BACKSLASH"     ) ;/ and ?
 
     ;; Lock keys
-    ((or 'capslock          'caps      ) "KC_CAPSLOCK"            ) ;Caps Lock
-    ((or 'scrollock         'slck      ) "KC_SCROLLOCK"           ) ;Scroll Lock, Brightness Down (macOS)
-    ((or 'numlock           'nlck      ) "KC_NUMLOCK"             ) ;Keypad Num Lock and Clear
-    ((or 'locking_caps      'lcap      ) "KC_LOCKING_CAPS"        ) ;Locking Caps Lock
-    ((or 'locking_num       'lnum      ) "KC_LOCKING_NUM"         ) ;Locking Num Lock
-    ((or 'locking_scroll    'lscr      ) "KC_LOCKING_SCROLL"      ) ;Locking Scroll Lock
+    ((or	'capslock          'caps      ) "KC_CAPS_LOCK"           ) ;Caps Lock
+    ((or	'scrollock 'scrl 'brmd 'slck  ) "KC_SCROLL_LOCK"         ) ;Scroll Lock,  Brightness Down (macOS)
+    ((or	'numlock   'num    'nlck      ) "KC_NUM_LOCK"            ) ;Keypad Num Lock and Clear
+    ((or	'locking_caps      'lcap      ) "KC_LOCKING_CAPS_LOCK"   ) ;Locking Caps Lock
+    ((or	'locking_num       'lnum      ) "KC_LOCKING_NUM_LOCK"    ) ;Locking Num Lock
+    ((or	'locking_scroll    'lscr      ) "KC_LOCKING_SCROLL_LOCK" ) ;Locking Scroll Lock
 
     ;; Modifiers
-    ((or 'lctl              'C         ) "KC_LCTL"                ) ;Left Control
-    ((or 'lalt              'M         ) "KC_LALT"                ) ;Left Alt
-    ((or 'lshift            'S         ) "KC_LSFT"                ) ;Left Shift
-    ((or 'lgui              'G         ) "KC_LGUI"                ) ;Left GUI (Windows/Command/Meta key)
-    ((or 'rctl              'rctrl     ) "KC_RCTRL"               ) ;Right Control
-    ((or 'ralt              'ropt      ) "KC_RALT"                ) ;Right Alt (Option/AltGr)
-    ((or 'rshift            'rsft      ) "KC_RSHIFT"              ) ;Right Shift
-    ((or 'rgui              'rcmd      ) "KC_RGUI"                ) ;Right GUI (Windows/Command/Meta key)
-    ((or 'hyper             'H         ) "KC_HYPR"                ) ;Hyper
+    ((or	'lctl              'C         ) "KC_LEFT_CTRL"           ) ;Left Control
+    ((or	'lalt              'M         ) "KC_LEFT_ALT"            )
+    ((or	'lshift    'lopt   'lsft 'S   ) "KC_LEFT_SHIFT"          ) ;Left Shift
+    ((or	'lgui      'lcmd   'lwin 'G   ) "KC_LEFT_GUI"            ) ;Left GUI (Windows/Command/Meta key)
+    ((or	'rctl              'rctrl     ) "KC_RIGHT_CTRL"          ) ;Right Control
+    ((or	'ralt      'algr   'ropt      ) "KC_RIGHT_ALT"           ) ;Right Alt (Option/AltGr)
+    ((or	'rshift            'rsft      ) "KC_RIGHT_SHIFT"         ) ;Right Shift
+    ((or	'rgui      'rcmd   'rwin      ) "KC_RIGHT_GUI"           ) ;Right GUI (Windows/Command/Meta key)
+    ((or	'hyper     'hypr   'H         ) "KC_HYPR"                ) ;Hyper
 
     ;; International
-    ((or 'ro                'int1      ) "INT1"                   ) ;JIS \ and _
-    ((or 'kana              'int2      ) "INT2"                   ) ;JIS Katakana/Hiragana
-    ((or 'jyen              'int3      ) "INT3"                   ) ;JIS ¥ and |
-    ((or 'henk              'int4      ) "INT4"                   ) ;JIS Henkan
-    ((or 'mhen              'int5      ) "INT5"                   ) ;JIS Muhenkan
-    (    'int6                           "INT6"                   ) ;JIS Numpad ,
-    (    'int7                           "INT7"                   ) ;International 7
-    (    'int8                           "INT8"                   ) ;International 8
-    (    'int9                           "INT9"                   ) ;International 9
-    ((or 'lang1             'haen      ) "LANG1"                  ) ;Hangul/English
-    ((or 'lang2             'hanj      ) "LANG2"                  ) ;Hanja
-    (    'lang3                          "LANG3"                  ) ;JIS Katakana
-    (    'lang4                          "LANG4"                  ) ;JIS Hiragana
-    (    'lang5                          "LANG5"                  ) ;JIS Zenkaku/Hankaku
-    (    'lang6                          "LANG6"                  ) ;Language 6
-    (    'lang7                          "LANG7"                  ) ;Language 7
-    (    'lang8                          "LANG8"                  ) ;Language 8
-    (    'lang9                          "LANG9"                  ) ;Language 9
+    ((or	'ro                'int1      ) "KC_INTERNATIONAL_1"     ) ;JIS \ and _
+    ((or	'kana              'int2      ) "KC_INTERNATIONAL_2"     ) ;JIS Katakana/Hiragana
+    ((or	'jyen              'int3      ) "KC_INTERNATIONAL_3"     ) ;JIS ¥ and |
+    ((or	'henk              'int4      ) "KC_INTERNATIONAL_4"     ) ;JIS Henkan
+    ((or	'mhen              'int5      ) "KC_INTERNATIONAL_5"     ) ;JIS Muhenkan
+    (   	'int6                           "KC_INTERNATIONAL_6"     ) ;JIS Numpad ,
+    (   	'int7                           "KC_INTERNATIONAL_7"     ) ;International 7
+    (   	'int8                           "KC_INTERNATIONAL_8"     ) ;International 8
+    (   	'int9                           "KC_INTERNATIONAL_9"     ) ;International 9
+    ((or	'lang1             'haen      ) "KC_LANGUAGE_1"          ) ;Hangul/English
+    ((or	'lang2             'hanj      ) "KC_LANGUAGE_2"          ) ;Hanja
+    (   	'lang3                          "KC_LANGUAGE_3"          ) ;JIS Katakana
+    (   	'lang4                          "KC_LANGUAGE_4"          ) ;JIS Hiragana
+    (   	'lang5                          "KC_LANGUAGE_5"          ) ;JIS Zenkaku/Hankaku
+    (   	'lang6                          "KC_LANGUAGE_6"          ) ;Language 6
+    (   	'lang7                          "KC_LANGUAGE_7"          ) ;Language 7
+    (   	'lang8                          "KC_LANGUAGE_8"          ) ;Language 8
+    (   	'lang9                          "KC_LANGUAGE_9"          ) ;Language 9
 
     ;; Commands
-    ((or 'pscreen           'pscr      ) "KC_PSCREEN"             ) ;Print Screen
-    ((or 'pause             'brk       ) "KC_PAUSE"               ) ;Pause, Brightness Up (macOS)
-    ((or 'insert            'ins       ) "KC_INSERT"              ) ;Insert
-    (    'home                           "KC_HOME"                ) ;Home
-    (    'pgup                           "KC_PGUP"                ) ;Page Up
-    ((or 'delete            'del       ) "KC_DELETE"              ) ;Forward Delete
-    (    'end                            "KC_END"                 ) ;End
-    ((or 'pgdown            'pgdn      ) "KC_PGDOWN"              ) ;Page Down
-    (    'right                          "KC_RIGHT"               ) ;Right Arrow
-    (    'left                           "KC_LEFT"                ) ;Left Arrow
-    (    'down                           "KC_DOWN"                ) ;Down Arrow
-    (    'up                             "KC_UP"                  ) ;Up Arrow
-    ((or 'application       'app       ) "KC_APPLICATION"         ) ;Application (Windows Context Menu Key)
-    (    'power                          "KC_POWER"               ) ;System Power
-    ((or 'execute           'exec      ) "KC_EXECUTE"             ) ;Execute
-    (    'help                           "KC_HELP"                ) ;Help
-    (    'menu                           "KC_MENU"                ) ;Menu
-    ((or 'select            'slct      ) "KC_SELECT"              ) ;Select
-    (    'stop                           "KC_STOP"                ) ;Stop
-    ((or 'again             'agin      ) "KC_AGAIN"               ) ;Again
-    (    'undo                           "KC_UNDO"                ) ;Undo
-    (    'cut                            "KC_CUT"                 ) ;Cut
-    (    'copy                           "KC_COPY"                ) ;Copy
-    ((or 'paste             'pste      ) "KC_PASTE"               ) ;Paste
-    (    'find                           "KC_FIND"                ) ;Find
-    (    '_mute                          "KC__MUTE"               ) ;Mute
-    (    '_volup                         "KC__VOLUP"              ) ;Volume Up
-    (    '_voldown                       "KC__VOLDOWN"            ) ;Volume Down
-    ((or 'alt_erase         'eras      ) "KC_ALT_erase"           ) ;Aternate Erase
-    (    'sysreq                         "KC_SYSREQ"              ) ;SysReq/Attention
-    (    'cancel                         "KC_CANCEL"              ) ;Cancel
-    ((or 'clear             'clr       ) "KC_CLEAR"               ) ;Clear
-    (    'prior                          "KC_PRIOR"               ) ;Prior
-    (    'return                         "KC_RETURN"              ) ;Return
-    (    'separator                      "KC_SEPARATOR"           ) ;Separator
-    (    'out                            "KC_OUT"                 ) ;Out
-    (    'oper                           "KC_OPER"                ) ;Open
-    (    'clear_again                    "KC_CLEAR_again"         ) ;Clear/Again
-    (    'crsel                          "KC_CRSEL"               ) ;CrSel/Props
-    (    'exsel                          "KC_EXSEL"               ) ;ExSel
+    ((or	'pscreen           'pscr      ) "KC_PRINT_SCREEN"        ) ;Print Screen
+    ((or	'pause       'paus 'brk 'brmu ) "KC_PAUSE"               ) ;Pause, Brightness Up (macOS)
+    ((or	'insert            'ins       ) "KC_INSERT"              ) ;Insert
+    (   	'home                           "KC_HOME"                ) ;Home
+    (   	'pgup                           "KC_PAGE_UP"             ) ;Page Up
+    ((or	'delete            'del       ) "KC_DELETE"              ) ;Forward Delete
+    (   	'end                            "KC_END"                 ) ;End
+    ((or	'pgdown            'pgdn      ) "KC_PAGE_DOWN"           ) ;Page Down
+    ((or	'right             'rght      ) "KC_RIGHT"               ) ;Right Arrow
+    (   	'left                           "KC_LEFT"                ) ;Left Arrow
+    (   	'down                           "KC_DOWN"                ) ;Down Arrow
+    (   	'up                             "KC_UP"                  ) ;Up Arrow
+    ((or	'application       'app       ) "KC_APPLICATION"         ) ;Application (Windows Context Menu Key)
+    (   	'kpwr                           "KC_KB_POWER"            ) ;Keyboard Power
+    ((or	'execute           'exec      ) "KC_EXECUTE"             ) ;Execute
+    (   	'help                           "KC_HELP"                ) ;Help
+    (   	'menu                           "KC_MENU"                ) ;Menu
+    ((or	'select            'slct      ) "KC_SELECT"              ) ;Select
+    (   	'stop                           "KC_STOP"                ) ;Stop
+    ((or	'again             'agin      ) "KC_AGAIN"               ) ;Again
+    (   	'undo                           "KC_UNDO"                ) ;Undo
+    (   	'cut                            "KC_CUT"                 ) ;Cut
+    (   	'copy                           "KC_COPY"                ) ;Copy
+    ((or	'paste             'pste      ) "KC_PASTE"               ) ;Paste
+    (   	'find                           "KC_FIND"                ) ;Find
+    (   	'_mute                          "KC__MUTE"               ) ;Mute
+    (   	'_volup                         "KC__VOLUP"              ) ;Volume Up
+    (   	'_voldown                       "KC__VOLDOWN"            ) ;Volume Down
+    ((or	'alt_erase         'eras      ) "KC_ALT_erase"           ) ;Aternate Erase
+    ((or	'sysreq            'syrq      ) "KC_SYSREQ"              ) ;SysReq/Attention
+    ((or	'cancel            'cncl      ) "KC_CANCEL"              ) ;Cancel
+    ((or	'clear             'clr       ) "KC_CLEAR"               ) ;Clear
+    ((or	'prior	           'prir      ) "KC_PRIOR"               ) ;Prior
+    ((or	'return            'retn      ) "KC_RETURN"              ) ;Return
+    ((or	'separator	       'sepr      ) "KC_SEPARATOR"           ) ;Separator
+    (   	'out                            "KC_OUT"                 ) ;Out
+    (   	'oper                           "KC_OPER"                ) ;Open
+    ((or	'clear_again       'clag      ) "KC_CLEAR_AGAIN"         ) ;Clear/Again
+    ((or	'crsel             'crsl      ) "KC_CRSEL"               ) ;CrSel/Props
+    ((or	'exsel             'exsl      ) "KC_EXSEL"               ) ;ExSel
 
     ;; Media Keys
-    ((or 'system-power      'pwr       ) "KC_SYSTEM_POWER"        ) ;System Power Down
-    ((or 'system-sleep      'slep      ) "KC_SYSTEM_SLEEP"        ) ;System Sleep
-    ((or 'system-wake       'wake      ) "KC_SYSTEM_WAKE"         ) ;System Wake
-    ((or 'audio-mute        'mute      ) "KC_AUDIO_MUTE"          ) ;Mute
-    ((or 'vol-up            'volu      ) "KC_AUDIO_VOL_UP"        ) ;Volume Up
-    ((or 'vol-down          'vold      ) "KC_AUDIO_VOL_DOWN"      ) ;Volume Down
-    ((or 'next-track        'mnxt      ) "KC_MEDIA_NEXT_TRACK"    ) ;Next Track
-    ((or 'prev-track        'mprv      ) "KC_MEDIA_PREV_TRACK"    ) ;Previous Track
-    ((or 'media-stop        'mstp      ) "KC_MEDIA_STOP"          ) ;Stop Track
-    ((or 'media-play-pause  'mply      ) "KC_MEDIA_PLAY_PAUSE"    ) ;Play/Pause Track
-    ((or 'media-select      'msel      ) "KC_MEDIA_SELECT"        ) ;Launch Media Player
-    ((or 'media-eject       'ejct      ) "KC_MEDIA_EJECT"         ) ;Eject
-    (    'mail                           "KC_MAIL"                ) ;Launch Mail
-    ((or 'calculator        'calc      ) "KC_CALCULATOR"          ) ;Launch Calculator
-    ((or 'my-computer       'mycm      ) "KC_MY_COMPUTER"         ) ;Launch My Computer
-    ((or 'www-search        'wsch      ) "KC_WWW_SEARCH"          ) ;Browser Search
-    ((or 'www-home          'whom      ) "KC_WWW_HOME"            ) ;Browser Home
-    ((or 'www-back          'wbak      ) "KC_WWW_BACK"            ) ;Browser Back
-    ((or 'www-forward       'wfwd      ) "KC_WWW_FORWARD"         ) ;Browser Forward
-    ((or 'www-stop          'wstp      ) "KC_WWW_STOP"            ) ;Browser Stop
-    ((or 'www-refresh       'wref      ) "KC_WWW_REFRESH"         ) ;Browser Refresh
-    ((or 'www-favorites     'wfav      ) "KC_WWW_FAVORITES"       ) ;Browser Favorites
-    ((or 'fast-forward      'mffd      ) "KC_MEDIA_FAST_FORWARD"  ) ;Next Track
-    ((or 'rewind            'mrwd      ) "KC_MEDIA_REWIND"        ) ;Previous Track
-    ((or 'brigthness-up     'briu      ) "KC_BRIGTHNESS_UP"       ) ;Brightness Up
-    ((or 'brigthness-down   'brid      ) "KC_BRIGTHNESS_DOWN"     ) ;Brightness Down
+    ((or	'system-power      'pwr       ) "KC_SYSTEM_POWER"        ) ;System Power Down
+    ((or	'system-sleep      'slep      ) "KC_SYSTEM_SLEEP"        ) ;System Sleep
+    ((or	'system-wake       'wake      ) "KC_SYSTEM_WAKE"         ) ;System Wake
+    ((or	'audio-mute        'mute      ) "KC_AUDIO_MUTE"          ) ;Mute
+    ((or	'vol-up            'volu      ) "KC_AUDIO_VOL_UP"        ) ;Volume Up
+    ((or	'vol-down          'vold      ) "KC_AUDIO_VOL_DOWN"      ) ;Volume Down
+    ((or	'next-track        'mnxt      ) "KC_MEDIA_NEXT_TRACK"    ) ;Next Track
+    ((or	'prev-track        'mprv      ) "KC_MEDIA_PREV_TRACK"    ) ;Previous Track
+    ((or	'media-stop        'mstp      ) "KC_MEDIA_STOP"          ) ;Stop Track
+    ((or	'media-play-pause  'mply      ) "KC_MEDIA_PLAY_PAUSE"    ) ;Play/Pause Track
+    ((or	'media-select      'msel      ) "KC_MEDIA_SELECT"        ) ;Launch Media Player
+    ((or	'media-eject       'ejct      ) "KC_MEDIA_EJECT"         ) ;Eject
+    (   	'mail                           "KC_MAIL"                ) ;Launch Mail
+    ((or	'calculator	       'calc      ) "KC_CALCULATOR"          ) ;Launch Calculator
+    ((or	'my-computer       'mycm      ) "KC_MY_COMPUTER"         ) ;Launch My Computer
+    ((or	'www-search        'wsch      ) "KC_WWW_SEARCH"          ) ;Browser Search
+    ((or	'www-home          'whom      ) "KC_WWW_HOME"            ) ;Browser Home
+    ((or	'www-back          'wbak      ) "KC_WWW_BACK"            ) ;Browser Back
+    ((or	'www-forward       'wfwd      ) "KC_WWW_FORWARD"         ) ;Browser Forward
+    ((or	'www-stop          'wstp      ) "KC_WWW_STOP"            ) ;Browser Stop
+    ((or	'www-refresh       'wref      ) "KC_WWW_REFRESH"         ) ;Browser Refresh
+    ((or	'www-favorites     'wfav      ) "KC_WWW_FAVORITES"       ) ;Browser Favorites
+    ((or	'fast-forward      'mffd      ) "KC_MEDIA_FAST_FORWARD"  ) ;Next Track
+    ((or	'rewind            'mrwd      ) "KC_MEDIA_REWIND"        ) ;Previous Track
+    ((or	'brigthness-up     'briu      ) "KC_BRIGHTNESS_UP"       ) ;Brightness Up
+    ((or	'brigthness-down   'brid      ) "KC_BRIGHTNESS_DOWN"     ) ;Brightness Down
 
     ;; Number Pad
-    ((or 'kp_slash          'psls      ) "KC_KP_SLASH"            ) ;Keypad /
-    ((or 'kp_asterisk       'past      ) "KC_KP_ASTERISK"         ) ;Keypad *
-    ((or 'kp_minus          'pmns      ) "KC_KP_MINUS"            ) ;Keypad -
-    ((or 'kp_plus           'ppls      ) "KC_KP_PLUS"             ) ;Keypad +
-    ((or 'kp_enter          'pent      ) "KC_KP_ENTER"            ) ;Enter
-    ((or 'kp_1              'p1        ) "KC_KP_1"                ) ;Keypad 1 and End
-    ((or 'kp_2              'p2        ) "KC_KP_2"                ) ;Keypad 2 and Down Arrow
-    ((or 'kp_3              'p3        ) "KC_KP_3"                ) ;Keypad 3 and Page Down
-    ((or 'kp_4              'p4        ) "KC_KP_4"                ) ;Keypad 4 and Left Arrow
-    ((or 'kp_5              'p5        ) "KC_KP_5"                ) ;Keypad 5
-    ((or 'kp_6              'p6        ) "KC_KP_6"                ) ;Keypad 6 and Right Arrow
-    ((or 'kp_7              'p7        ) "KC_KP_7"                ) ;Keypad 7 and Home
-    ((or 'kp_8              'p8        ) "KC_KP_8"                ) ;Keypad 8 and Up Arrow
-    ((or 'kp_9              'p9        ) "KC_KP_9"                ) ;Keypad 9 and Page Up
-    ((or 'kp_0              'p0        ) "KC_KP_0"                ) ;Keypad 0 and Insert
-    ((or 'kp_dot            'pdot      ) "KC_KP_DOT"              ) ;Keypad . and Delete
-    ((or 'kp_equal          'peql      ) "KC_KP_EQUAL"            ) ;Keypad =
-    ((or 'kp_comma          'pcmm      ) "KC_KP_COMMA"            ) ;Keypad ,
-    (    'kp_equal_as400                 "KC_KP_EQUAL_AS400"      ) ;Keypad = on AS/400 keyboards
+    ((or	'kp_slash          'psls      ) "KC_KP_SLASH"            ) ;Keypad /
+    ((or	'kp_asterisk       'past      ) "KC_KP_ASTERISK"         ) ;Keypad *
+    ((or	'kp_minus          'pmns      ) "KC_KP_MINUS"            ) ;Keypad -
+    ((or	'kp_plus           'ppls      ) "KC_KP_PLUS"             ) ;Keypad +
+    ((or	'kp_enter          'pent      ) "KC_KP_ENTER"            ) ;Enter
+    ((or	'kp_1              'p1        ) "KC_KP_1"                ) ;Keypad 1 and End
+    ((or	'kp_2              'p2        ) "KC_KP_2"                ) ;Keypad 2 and Down Arrow
+    ((or	'kp_3              'p3        ) "KC_KP_3"                ) ;Keypad 3 and Page Down
+    ((or	'kp_4              'p4        ) "KC_KP_4"                ) ;Keypad 4 and Left Arrow
+    ((or	'kp_5              'p5        ) "KC_KP_5"                ) ;Keypad 5
+    ((or	'kp_6              'p6        ) "KC_KP_6"                ) ;Keypad 6 and Right Arrow
+    ((or	'kp_7              'p7        ) "KC_KP_7"                ) ;Keypad 7 and Home
+    ((or	'kp_8              'p8        ) "KC_KP_8"                ) ;Keypad 8 and Up Arrow
+    ((or	'kp_9              'p9        ) "KC_KP_9"                ) ;Keypad 9 and Page Up
+    ((or	'kp_0              'p0        ) "KC_KP_0"                ) ;Keypad 0 and Insert
+    ((or	'kp_dot            'pdot      ) "KC_KP_DOT"              ) ;Keypad . and Delete
+    ((or	'kp_equal          'peql      ) "KC_KP_EQUAL"            ) ;Keypad =
+    ((or	'kp_comma          'pcmm      ) "KC_KP_COMMA"            ) ;Keypad ,
+    (   	'kp_equal_as400                 "KC_KP_EQUAL_AS400"      ) ;Keypad = on AS/400 keyboards
 
     ;; Special Keys
-    ((pred (eq mugur-ignore-key       )) "KC_NO"                 ) ;Ignore this key (NOOP)
-    ((pred (eq mugur-transparent-key  )) "KC_TRNS"               ) ;Use the next lowest non-transparent key
+    ((pred (eq mugur-ignore-key)          ) "KC_NO"                  ) ;Ignore this key (NOOP)
+    ((pred (eq mugur-transparent-key)     ) "KC_TRNS"                ) ;Use the next lowest non-transparent key
     
     ;; Quantum Keycodes
-    (    'reset                          "RESET"                  ) ;Put the keyboard into bootloader mode for flashing
-    (    'debug                          "DEBUG"                  ) ;Toggle debug mode
-    ((or 'eeprom-reset      'eep_rst   ) "EEPROM_RESET"           ) ;Reinitializes the keyboard’s EEPROM (persistent memory)
+    (   	'reset                          "RESET"                  ) ;Put the keyboard into bootloader mode for	flashing
+    (   	'debug                          "DEBUG"                  ) ;Toggle debug mode
+    ((or	'eeprom-reset      'eep_rst   ) "EEPROM_RESET"           ) ;Reinitializes the keyboard’s EEPROM (persistent memory)
         
     ;; Dynamic Macros
-    ((or 'dyn_rec_start1    'dm_rec1   ) "KC_DYN_REC_START1"      ) ;Start recording Macro 1
-    ((or 'dyn_rec_start2    'dm_rec2   ) "KC_DYN_REC_START1"      ) ;Start recording Macro 2
-    ((or 'dyn_macro_play1   'dm_ply1   ) "KC_DYN_MACRO_PLAY1"     ) ;Replay Macro 1
-    ((or 'dyn_macro_play2   'dm_ply2   ) "KC_DYN_MACRO_PLAY1"     ) ;Replay Macro 2
-    ((or 'dyn_rec_stop      'dm_rstp   ) "KC_DYN_REC_STOP"        ) ;Finish the macro that is currently being recorded.
+    ((or	'dyn_rec_start1    'dm_rec1   ) "KC_DYN_REC_START1"      ) ;Start recording Macro 1
+    ((or	'dyn_rec_start2    'dm_rec2   ) "KC_DYN_REC_START1"      ) ;Start recording Macro 2
+    ((or	'dyn_macro_play1   'dm_ply1   ) "KC_DYN_MACRO_PLAY1"     ) ;Replay Macro 1
+    ((or	'dyn_macro_play2   'dm_ply2   ) "KC_DYN_MACRO_PLAY1"     ) ;Replay Macro 2
+    ((or	'dyn_rec_stop      'dm_rstp   ) "KC_DYN_REC_STOP"        ) ;Finish the macro that is currently being recorded.
 
     ;; Grave Escape
-    ((or 'gesc              'grave_esc ) "KC_GESC"                ) ;Escape when pressed, ` when Shift or GUI are held
+    ((or	'gesc              'grave_esc ) "KC_GRAVE_ESCAPE"        ) ;Escape when pressed, ` when Shift or	GUI are held
 
     ;; Leader Key
-    (    'lead                           "KC_LEAD"                ) ;The Leader Key
+    (   	'lead                           "KC_LEAD"                ) ;The Leader Key
 
     ;; Mouse Keys
-    ((or 'ms_up             'ms_u      ) "KC_MS_UP"               ) ;Move cursor up
-    ((or 'ms_down           'ms_d      ) "KC_MS_DOWN"             ) ;Move cursor down
-    ((or 'ms_left           'ms_l      ) "KC_MS_LEFT"             ) ;Move cursor left
-    ((or 'ms_right          'ms_r      ) "KC_MS_RIGHT"            ) ;Move cursor right
-    ((or 'ms_btn1           'btn1      ) "KC_MS_BTN1"             ) ;Press button 1
-    ((or 'ms_btn2           'btn2      ) "KC_MS_BTN2"             ) ;Press button 2
-    ((or 'ms_btn3           'btn3      ) "KC_MS_BTN3"             ) ;Press button 3
-    ((or 'ms_btn4           'btn4      ) "KC_MS_BTN4"             ) ;Press button 4
-    ((or 'ms_btn5           'btn5      ) "KC_MS_BTN5"             ) ;Press button 5
-    ((or 'ms_btn6           'btn6      ) "KC_MS_BTN6"             ) ;Press button 6
-    ((or 'ms_btn7           'btn7      ) "KC_MS_BTN7"             ) ;Press button 7
-    ((or 'ms_btn8           'btn8      ) "KC_MS_BTN8"             ) ;Press button 8
-    ((or 'ms_wh_up          'wh_u      ) "KC_MS_WH_UP"            ) ;Move wheel up
-    ((or 'ms_wh_down        'wh_d      ) "KC_MS_WH_DOWN"          ) ;Move wheel down
-    ((or 'ms_wh_left        'wh_l      ) "KC_MS_WH_LEFT"          ) ;Move wheel left
-    ((or 'ms_wh_right       'wh_r      ) "KC_MS_WH_RIGHT"         ) ;Move wheel right
-    ((or 'ms_accel0         'acl0      ) "KC_MS_ACCEL0"           ) ;Set speed to 0
-    ((or 'ms_accel1         'acl1      ) "KC_MS_ACCEL1"           ) ;Set speed to 1
-    ((or 'ms_accel2         'acl2      ) "KC_MS_ACCEL2"           ) ;Set speed to 2
+    ((or	'ms_up             'ms_u      ) "KC_MS_UP"               ) ;Move cursor	up
+    ((or	'ms_down           'ms_d      ) "KC_MS_DOWN"             ) ;Move cursor	down
+    ((or	'ms_left           'ms_l      ) "KC_MS_LEFT"             ) ;Move cursor	left
+    ((or	'ms_right          'ms_r      ) "KC_MS_RIGHT"            ) ;Move cursor	right
+    ((or	'ms_btn1           'btn1      ) "KC_MS_BTN1"             ) ;Press button 1
+    ((or	'ms_btn2           'btn2      ) "KC_MS_BTN2"             ) ;Press button 2
+    ((or	'ms_btn3           'btn3      ) "KC_MS_BTN3"             ) ;Press button 3
+    ((or	'ms_btn4           'btn4      ) "KC_MS_BTN4"             ) ;Press button 4
+    ((or	'ms_btn5           'btn5      ) "KC_MS_BTN5"             ) ;Press button 5
+    ((or	'ms_btn6           'btn6      ) "KC_MS_BTN6"             ) ;Press button 6
+    ((or	'ms_btn7           'btn7      ) "KC_MS_BTN7"             ) ;Press button 7
+    ((or	'ms_btn8           'btn8      ) "KC_MS_BTN8"             ) ;Press button 8
+    ((or	'ms_wh_up          'wh_u      ) "KC_MS_WH_UP"            ) ;Move wheel up
+    ((or	'ms_wh_down        'wh_d      ) "KC_MS_WH_DOWN"          ) ;Move wheel down
+    ((or	'ms_wh_left        'wh_l      ) "KC_MS_WH_LEFT"          ) ;Move wheel left
+    ((or	'ms_wh_right       'wh_r      ) "KC_MS_WH_RIGHT"         ) ;Move wheel right
+    ((or	'ms_accel0         'acl0      ) "KC_MS_ACCEL0"           ) ;Set speed to 0
+    ((or	'ms_accel1         'acl1      ) "KC_MS_ACCEL1"           ) ;Set speed to 1
+    ((or	'ms_accel2         'acl2      ) "KC_MS_ACCEL2"           ) ;Set speed to 2
         
     ;; Space Cadet
-    (    'lspo                           "KC_LSPO"                ) ;Left Shift when held, ( when tapped
-    (    'rspc                           "KC_RSPC"                ) ;Right Shift when held, ) when tapped
-    (    'lcpo                           "KC_LCPO"                ) ;Left Control when held, ( when tapped
-    (    'rcpc                           "KC_RCPC"                ) ;Right Control when held, ) when tapped
-    (    'lapo                           "KC_LAPO"                ) ;Left Alt when held, ( when tapped
-    (    'rapc                           "KC_RAPC"                ) ;Right Alt when held, ) when tapped
-    (    'sftent                         "KC_SFTENT"              ) ;Right Shift when held, Enter when tapped
+    (   	'lspo                           "KC_LSPO"                ) ;Left Shift when held, (   	when tapped
+    (   	'rspc                           "KC_RSPC"                ) ;Right Shift when held, ) when tapped
+    (   	'lcpo                           "KC_LCPO"                ) ;Left Control when held, (   	when tapped
+    (   	'rcpc                           "KC_RCPC"                ) ;Right Control when held, ) when tapped
+    (   	'lapo                           "KC_LAPO"                ) ;Left Alt when held, (   	when tapped
+    (   	'rapc                           "KC_RAPC"                ) ;Right Alt when held, ) when tapped
+    (   	'sftent                         "KC_SFTENT"              ) ;Right Shift when held, Enter when tapped
 
     ;; US ANSI Shifted Symbols
-    ((or 'tilde              ?\~       ) "KC_TILDE"               ) ;~
-    ((or 'exclaim            ?\!       ) "KC_EXCLAIM"             ) ;!
-    ((or 'at                 ?\@       ) "KC_AT"                  ) ;@
-    ((or 'hash               ?\#       ) "KC_HASH"                ) ;#
-    ((or 'dollar             ?\$       ) "KC_DOLLAR"              ) ;$
-    ((or 'percent            ?\%       ) "KC_PERCENT"             ) ;%
-    ((or 'circumflex         ?\^       ) "KC_CIRCUMFLEX"          ) ;^
-    ((or 'ampersand          ?\&       ) "KC_AMPERSAND"           ) ;&
-    ((or 'asterisk           ?\*       ) "KC_ASTERISK"            ) ;*
-    ((or 'lparen             ?\(       ) "KC_LEFT_PAREN"          ) ;(
-    ((or 'rparen             ?\)       ) "KC_RIGHT_PAREN"         ) ;)
-    ((or 'under              ?\_       ) "KC_UNDERSCORE"          ) ;_
-    ((or 'plus               ?\+       ) "KC_PLUS"                ) ;+
-    ((or 'left_curly         ?\{       ) "KC_LEFT_CURLY_BRACE"    ) ;{
-    ((or 'right_curly        ?\}       ) "KC_RIGHT_CURLY_BRACE"   ) ;}
-    ((or 'pipe               ?\|       ) "KC_PIPE"                ) ;|
-    ((or 'colon              ?\:       ) "KC_COLON"               ) ;:
-    ((or 'double_quote       ?\"       ) "KC_DOUBLE_QUOTE"        ) ;"
-    ((or 'left_angle         ?\<       ) "KC_LEFT_ANGLE_BRACKET"  ) ;<
-    ((or 'right_angle        ?\>       ) "KC_RIGHT_ANGLE_BRACKET" ) ;>
-    ((or 'question           ?\?       ) "KC_QUESTION"            ) ;?
+    ((or	'tilde              ?\~       ) "KC_TILDE"               ) ;~
+    ((or	'exclaim            ?\!       ) "KC_EXCLAIM"             ) ;!
+    ((or	'at                 ?\@       ) "KC_AT"                  ) ;@
+    ((or	'hash               ?\#       ) "KC_HASH"                ) ;#
+    ((or	'dollar             ?\$       ) "KC_DOLLAR"              ) ;$
+    ((or	'percent            ?\%       ) "KC_PERCENT"             ) ;%
+    ((or	'circumflex         ?\^       ) "KC_CIRCUMFLEX"          ) ;^
+    ((or	'ampersand          ?\&       ) "KC_AMPERSAND"           ) ;&
+    ((or	'asterisk           ?\*       ) "KC_ASTERISK"            ) ;*
+    ((or	'lparen             ?\(   	  ) "KC_LEFT_PAREN"          ) ;(
+    ((or	'rparen             ?\)       ) "KC_RIGHT_PAREN"         ) ;)
+    ((or	'under              ?\_       ) "KC_UNDERSCORE"          ) ;_
+    ((or	'plus               ?\+       ) "KC_PLUS"                ) ;+
+    ((or	'left_curly         ?\{       ) "KC_LEFT_CURLY_BRACE"    ) ;{
+    ((or	'right_curly        ?\}       ) "KC_RIGHT_CURLY_BRACE"   ) ;}
+    ((or	'pipe               ?\|       ) "KC_PIPE"                ) ;|
+    ((or	'colon              ?\:       ) "KC_COLON"               ) ;:
+    ((or	'double_quote       ?\"       ) "KC_DOUBLE_QUOTE"        ) ;"
+    ((or	'left_angle         ?\<       ) "KC_LEFT_ANGLE_BRACKET"  ) ;<
+    ((or	'right_angle        ?\>       ) "KC_RIGHT_ANGLE_BRACKET" ) ;>
+    ((or	'question           ?\?       ) "KC_QUESTION"            ) ;?
 
     ;; Combos
-    (    'combo_on                       "CMB_ON"                 ) ;Turn on Combo feature
-    (    'combo_off                      "CMB_OFF"                ) ;Turn off Combo feature
-    (    'combo_tog                      "CMB_TOG"                ) ;Toggle Combo feature on and off
+    ((or	'combo_on           'cmb_on   ) "CMB_ON"                 ) ;Turn on Combo feature
+    ((or	'combo_off          'cmb_off  ) "CMB_OFF"                ) ;Turn off Combo feature
+    ((or	'combo_tog          'cmb_tog  ) "CMB_TOG"                ) ;Toggle Combo feature on and off
     
     ;; RGB Ligthing
-    (    'rgb_tog                        "RGB_TOG"                ) ;Toggle RGB lighting on or off
-    ((or 'rgb_mode_forward  'rgb_mod   ) "RGB_MOD"                ) ;Cycle through modes, reverse direction when Shift is held
-    ((or 'rgb_mode_reverse  'rgb_mod   ) "RGB_RMOD"               ) ;Cycle through modes in reverse, forward direction when Shift is held
-    (    'rgb_hui                        "RGB_HUI"                ) ;Increase hue, decrease hue when Shift is held
-    (    'rgb_hud                        "RGB_HUD"                ) ;Decrease hue, increase hue when Shift is held
-    (    'rgb_sai                        "RGB_SAI"                ) ;Increase saturation, decrease saturation when Shift is held
-    (    'rgb_sad                        "RGB_SAD"                ) ;Decrease saturation, increase saturation when Shift is held
-    (    'rgb_vai                        "RGB_VAI"                ) ;Increase value (brightness), decrease value when Shift is held
-    (    'rgb_vad                        "RGB_VAD"                ) ;Decrease value (brightness), increase value when Shift is held
-    ((or 'rgb_mode_plain    'rgb_m_p   ) "RGB_MOIDE_PLAIN"        ) ;Static (no animation) mode
-    ((or 'rgb_mode_breathe  'rgb_m_b   ) "RGB_MODE_BREATHE"       ) ;Breathing animation mode
-    ((or 'rgb_mode_rainbow  'rgb_m_r   ) "RGB_MODE_RAINBOW"       ) ;Rainbow animation mode
-    ((or 'rgb_mode_swirl    'rgb_m_sw  ) "RGB_MODE_SWIRL"         ) ;Swirl animation mode
-    ((or 'rgb_mode_snake    'rgb_m_sn  ) "RGB_MODE_SNAKE"         ) ;Snake animation mode
-    ((or 'rgb_mode_knight   'rgb_m_k   ) "RGB_MODE_KNIGHT"        ) ;"Knight Rider" animation mode
-    ((or 'rgb_mode_xmas     'rgb_m_x   ) "RGB_MODE_XMAS"          ) ;Christmas animation mode
-    ((or 'rgb_mode_gradient 'rgb_m_g   ) "RGB_MODE_GRADIENT"      ) ;Static gradient animation mode
-    ((or 'rgb_mode_rgbtest  'rgb_m_t   ) "RGB_MODE_RGBTEST"       ) ;Red, Green, Blue test animation mode
+    (   	'rgb_tog                        "RGB_TOG"                ) ;Toggle RGB lighting on or	off
+    ((or	'rgb_mode_forward  'rgb_mod   ) "RGB_MOD"                ) ;Cycle through modes, reverse direction when Shift is held
+    ((or	'rgb_mode_reverse  'rgb_mod   ) "RGB_RMOD"               ) ;Cycle through modes in reverse, forward direction when Shift is held
+    (   	'rgb_hui                        "RGB_HUI"                ) ;Increase hue, decrease hue when Shift is held
+    (   	'rgb_hud                        "RGB_HUD"                ) ;Decrease hue, increase hue when Shift is held
+    (   	'rgb_sai                        "RGB_SAI"                ) ;Increase saturation, decrease saturation when Shift is held
+    (   	'rgb_sad                        "RGB_SAD"                ) ;Decrease saturation, increase saturation when Shift is held
+    (   	'rgb_vai                        "RGB_VAI"                ) ;Increase value (brightness), decrease value when Shift is held
+    (   	'rgb_vad                        "RGB_VAD"                ) ;Decrease value (brightness), increase value when Shift is held
+    ((or	'rgb_mode_plain    'rgb_m_p   ) "RGB_MOIDE_PLAIN"        ) ;Static (no animation) mode
+    ((or	'rgb_mode_breathe  'rgb_m_b   ) "RGB_MODE_BREATHE"       ) ;Breathing animation mode
+    ((or	'rgb_mode_rainbow  'rgb_m_r   ) "RGB_MODE_RAINBOW"       ) ;Rainbow animation mode
+    ((or	'rgb_mode_swirl    'rgb_m_sw  ) "RGB_MODE_SWIRL"         ) ;Swirl animation mode
+    ((or	'rgb_mode_snake    'rgb_m_sn  ) "RGB_MODE_SNAKE"         ) ;Snake animation mode
+    ((or	'rgb_mode_knight   'rgb_m_k   ) "RGB_MODE_KNIGHT"        ) ;"Knight Rider" animation mode
+    ((or	'rgb_mode_xmas     'rgb_m_x   ) "RGB_MODE_XMAS"          ) ;Christmas animation mode
+    ((or	'rgb_mode_gradient 'rgb_m_g   ) "RGB_MODE_GRADIENT"      ) ;Static gradient animation mode
+    ((or	'rgb_mode_rgbtest  'rgb_m_t   ) "RGB_MODE_RGBTEST"       ) ;Red, Green, Blue test animation mode
 
     ;; Key Lock
-    (    'lock                           "KC_LOCK"              ))) ;Hold down the next key pressed, until the key is pressed again
+    (   	'lock                           "KC_LOCK"                ) ;Hold down the next key pressed, until the key is pressed again
+
+    ;; Tapping Term
+    (   	'dtpr                           "DT_PRNT"                )
+    (   	'dtup                           "DT_UP"                  )
+    (   	'dtdn                           "DT_DOWN"                )
+    ;; Auto Shift
+    (   	'asup                           "KC_ASUP"                )
+    (   	'asdn                           "KC_ASDN"                )
+    (   	'asrp                           "KC_ASRP"                )
+    (   	'astg                           "KC_ASTG"                )
+    (   	'ason                           "KC_ASON"                )
+    (   	'asoff                          "KC_ASOFF"               )
+    )) 
 
 (defun mugur--modifier (mugur-key)
   "Handle a modifier MUGUR-KEY.
@@ -879,7 +893,7 @@ qmk-keymaps folder, as required by the qmk rules."
    (format
     "#include QMK_KEYBOARD_H
       #include \"version.h\"
-            
+      #include \"quantum.h\"
       /* Macros */
       %s
 


### PR DESCRIPTION
This is an update to the keycodes accepted my mugur. I used the current
keycodes from here
https://github.com/qmk/qmk_firmware/blob/main/quantum/keycode.h and also
needed to add an `#include "quantum.h"` to the keymap.c file generation.