### PR TITLE
add tapping toggle and raw config options

### DIFF
--- a/mugur.el
+++ b/mugur.el
@@ -87,6 +87,12 @@ your keyboard.  Some have just \"LAYOUT\", others
   :type '(integer :tag "ms")
   :group 'mugur)
 
+(defcustom mugur-tapping-toggle nil
+  "Tapping toggle.
+ This is the number of times you need to tap to toggle a layer with Tap-Toggle."
+  :type '(integer)
+  :group 'mugur)
+
 (defcustom mugur-combo-term 300
   "Combo term, in ms.
  This is the maximum time allowed between two keypresses in which
@@ -867,6 +873,7 @@ required by the qmk rules."
    (format
     "#undef TAPPING_TERM
      #define TAPPING_TERM %s
+     %s
      #define COMBO_TERM %s
      #define LEADER_TIMEOUT %s
      %s      LEADER_PER_KEY_TIMING
@@ -874,6 +881,9 @@ required by the qmk rules."
      #define FORCE_NKRO
      #undef RGBLIGHT_ANIMATIONS"
     mugur-tapping-term
+    (if mugur-tapping-toggle
+        (format "#define TAPPING_TOGGLE %d" mugur-tapping-toggle)
+      "")
     mugur-combo-term
     mugur-leader-timeout
     (if mugur-leader-per-key-timing

--- a/mugur.el
+++ b/mugur.el
@@ -114,6 +114,11 @@ tapped."
   :type '(integer :tag "ms")
   :group 'mugur)
 
+(defcustom mugur-raw-config nil
+  "Raw config to insert in config.h"
+  :type '(string :tag "config")
+  :group 'mugur)
+
 ;; Others
 (defcustom mugur-leader-keys nil
   "List of Leader Keys and their expansion.
@@ -879,7 +884,9 @@ required by the qmk rules."
      %s      LEADER_PER_KEY_TIMING
      #define COMBO_COUNT %s
      #define FORCE_NKRO
-     #undef RGBLIGHT_ANIMATIONS"
+     #undef RGBLIGHT_ANIMATIONS
+
+     %s"
     mugur-tapping-term
     (if mugur-tapping-toggle
         (format "#define TAPPING_TOGGLE %d" mugur-tapping-toggle)
@@ -888,7 +895,10 @@ required by the qmk rules."
     mugur-leader-timeout
     (if mugur-leader-per-key-timing
         "#define" "#undef")
-    (length mugur-combo-keys))))
+    (length mugur-combo-keys)
+    (if mugur-raw-config
+        mugur-raw-config
+      ""))))
 
 (defun mugur--write-keymap-c (qmk-keymap)
   "Generate the qmk keymap.c file from the MUGUR-KEYMAP.


### PR DESCRIPTION
Hi!
This pull request adds two things that I need:
1. add the `mugur-tapping-toggle` variable to be able to configure `TAPPING_TOGGLE` in `config.h`
2. add the ability to insert raw config in `config.h`, so that you can encode your config in mugur instead of manually editing the output file

Let me know if anything is needed to merge
cheers